### PR TITLE
YONK-811: Enable oAuth2 for mobile app configuration APIs

### DIFF
--- a/mobileapps/tests.py
+++ b/mobileapps/tests.py
@@ -39,6 +39,10 @@ class NotificationProviderApiTests(ModuleStoreTestCase, APIClientMixin):
         self.test_provider_name = "Test Provider Name"
         self.test_api_url = "http://example.com"
 
+        self.user = UserFactory.create(username='test', email='test@edx.org', password='test_password')
+        self.client = Client()
+        self.client.login(username=self.user.username, password='test_password')
+
         cache.clear()
 
     def setup_test_notification_provider(self, notification_provider_data=None):
@@ -611,9 +615,6 @@ class MobileappsNotificationsTests(ModuleStoreTestCase, APIClientMixin):
         organizations = [organization1, organization2]
 
         cls.organization1_id = organization1.id
-        cls.user = UserFactory.create(username='test', email='test@edx.org', password='test_password')
-        cls.client = Client()
-        cls.client.login(username=cls.user.username, password='test_password')
 
         app_data = {
             'identifier': 'ABC identifier',
@@ -640,6 +641,15 @@ class MobileappsNotificationsTests(ModuleStoreTestCase, APIClientMixin):
         cls.mobile_app3_id = mobile_app3.id
 
         startup.initialize()
+        cache.clear()
+
+    def setUp(self):
+        super(MobileappsNotificationsTests, self).setUp()
+
+        self.user = UserFactory.create(username='test', email='test@edx.org', password='test_password')
+        self.client = Client()
+        self.client.login(username=self.user.username, password='test_password')
+
         cache.clear()
 
     @classmethod

--- a/mobileapps/views.py
+++ b/mobileapps/views.py
@@ -8,10 +8,10 @@ from rest_framework.response import Response
 from edx_notifications.data import NotificationMessage
 from edx_notifications.lib.publisher import get_notification_type
 from edx_solutions_api_integration.permissions import (
-    SecureListCreateAPIView,
-    SecureRetrieveUpdateAPIView,
-    SecureListAPIView,
-    SecureAPIView,
+    MobileAPIView,
+    MobileListAPIView,
+    MobileListCreateAPIView,
+    MobileRetrieveUpdateAPIView,
 )
 from edx_solutions_api_integration.users.serializers import SimpleUserSerializer
 from edx_solutions_organizations.models import Organization
@@ -23,7 +23,7 @@ from mobileapps.serializers import MobileAppSerializer, NotificationProviderSeri
 from mobileapps.tasks import publish_mobile_apps_notifications_task
 
 
-class NotificationProviderView(SecureListAPIView):
+class NotificationProviderView(MobileListAPIView):
     """
     **Use Case**
 
@@ -51,7 +51,7 @@ class NotificationProviderView(SecureListAPIView):
     queryset = NotificationProvider.objects.all()
 
 
-class MobileAppView(SecureListCreateAPIView):
+class MobileAppView(MobileListCreateAPIView):
     """
     **Use Case**
 
@@ -179,7 +179,7 @@ class MobileAppView(SecureListCreateAPIView):
         return queryset
 
 
-class MobileAppDetailView(SecureRetrieveUpdateAPIView):
+class MobileAppDetailView(MobileRetrieveUpdateAPIView):
     """
     **Use Case**
 
@@ -260,7 +260,7 @@ class MobileAppDetailView(SecureRetrieveUpdateAPIView):
     serializer_class = MobileAppSerializer
 
 
-class MobileAppUserView(SecureListAPIView):
+class MobileAppUserView(MobileListAPIView):
     """
     **Use Case**
 
@@ -324,7 +324,7 @@ class MobileAppUserView(SecureListAPIView):
             raise Http404
 
 
-class MobileAppOrganizationView(SecureListAPIView):
+class MobileAppOrganizationView(MobileListAPIView):
     """
     **Use Case**
 
@@ -388,7 +388,7 @@ class MobileAppOrganizationView(SecureListAPIView):
             raise Http404
 
 
-class MobileAppAllUsersNotifications(SecureAPIView):
+class MobileAppAllUsersNotifications(MobileAPIView):
     """
     **Use Cases**
 
@@ -446,7 +446,7 @@ class MobileAppAllUsersNotifications(SecureAPIView):
         return Response({'message': _('Accepted')}, status.HTTP_202_ACCEPTED)
 
 
-class MobileAppSelectedUsersNotifications(SecureAPIView):
+class MobileAppSelectedUsersNotifications(MobileAPIView):
     """
     **Use Cases**
 
@@ -507,7 +507,7 @@ class MobileAppSelectedUsersNotifications(SecureAPIView):
         return Response({'message': _('Accepted')}, status.HTTP_202_ACCEPTED)
 
 
-class MobileAppOrganizationAllUsersNotifications(SecureAPIView):
+class MobileAppOrganizationAllUsersNotifications(MobileAPIView):
     """
     **Use Cases**
 


### PR DESCRIPTION
Changes include views with oAuth2 support for mobile app configuration APIs. 