### PR TITLE
prefix_with_lms_base removed from logo image urls

### DIFF
--- a/mobileapps/image_helpers.py
+++ b/mobileapps/image_helpers.py
@@ -166,7 +166,6 @@ def get_logo_image_urls_by_organization_name(key, logo_image_uploaded_at):
             get_logo_image_storage(),
             version=logo_image_uploaded_at.strftime("%s"),
         )
-        urls = {size_display_name: prefix_with_lms_base(url) for size_display_name, url in urls.items()}
     else:
         urls = _get_default_logo_image_urls()
         urls = {size_display_name: prefix_with_lms_base(url) for size_display_name, url in urls.items()}

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='mobileapps-edx-platform-extensions',
-    version='1.1.1',
+    version='1.1.2',
     description='Mobile apps management extension for edX platform',
     long_description=open('README.md').read(),
     author='edX',


### PR DESCRIPTION
Changes include removal of prefix_with_lms_base from logo image urls