### PR TITLE
YONK-841: separate permissions for non staff users

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='mobileapps-edx-platform-extensions',
-    version='1.1.2',
+    version='1.1.3',
     description='Mobile apps management extension for edX platform',
     long_description=open('README.md').read(),
     author='edX',
@@ -13,6 +13,5 @@ setup(
     include_package_data=True,
     install_requires=[
         "django>=1.8",
-        'djangorestframework>=3.2.0',
     ],
 )


### PR DESCRIPTION
This PR has changes to limit add/update/delete operations on themes, mobiles apps to only staff users and limit retrieval of themes and mobile apps with the organization members for non staff users. YONK-841 has details of the requirements this PR fulfills.
@aamishbaloch could you please review?