### PR TITLE
YONK-851: added new field ios_bundle_id

### DIFF
--- a/mobileapps/migrations/0006_auto_20171229_0720.py
+++ b/mobileapps/migrations/0006_auto_20171229_0720.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('mobileapps', '0005_auto_20171219_0647'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='mobileapp',
+            name='ios_bundle_id',
+            field=models.CharField(db_index=True, max_length=255, null=True, blank=True),
+        ),
+        migrations.AddField(
+            model_name='mobileapphistory',
+            name='ios_bundle_id',
+            field=models.CharField(db_index=True, max_length=255, null=True, blank=True),
+        ),
+    ]

--- a/mobileapps/models.py
+++ b/mobileapps/models.py
@@ -49,6 +49,7 @@ class MobileApp(TimeStampedModel):
     """
     name = models.CharField(max_length=255)
     ios_app_id = models.CharField(max_length=255, db_index=True, null=True, blank=True)
+    ios_bundle_id = models.CharField(max_length=255, db_index=True, null=True, blank=True)
     android_app_id = models.CharField(max_length=255, db_index=True, null=True, blank=True)
     ios_download_url = models.CharField(max_length=255, null=True, blank=True)
     android_download_url = models.CharField(max_length=255, null=True, blank=True)
@@ -91,6 +92,7 @@ class MobileAppHistory(models.Model):
     """
     name = models.CharField(max_length=255)
     ios_app_id = models.CharField(max_length=255, db_index=True, null=True, blank=True)
+    ios_bundle_id = models.CharField(max_length=255, db_index=True, null=True, blank=True)
     android_app_id = models.CharField(max_length=255, db_index=True, null=True, blank=True)
     ios_download_url = models.CharField(max_length=255, null=True, blank=True)
     android_download_url = models.CharField(max_length=255, null=True, blank=True)
@@ -115,6 +117,7 @@ def user_post_save_callback(sender, **kwargs):
     mobile_app_history = MobileAppHistory()
     mobile_app_history.name = mobile_app.name
     mobile_app_history.ios_app_id = mobile_app.ios_app_id
+    mobile_app_history.ios_bundle_id = mobile_app.ios_bundle_id
     mobile_app_history.android_app_id = mobile_app.android_app_id
     mobile_app_history.ios_download_url = mobile_app.ios_download_url
     mobile_app_history.android_download_url = mobile_app.android_download_url

--- a/mobileapps/tests.py
+++ b/mobileapps/tests.py
@@ -106,6 +106,7 @@ class MobileappsApiTests(ModuleStoreTestCase, APIClientMixin):
 
         self.test_mobileapp_name = str(uuid.uuid4())
         self.test_mobileapp_ios_app_id = str(uuid.uuid4())
+        self.test_mobileapp_ios_bundle_id = str(uuid.uuid4())
         self.test_mobileapp_android_app_id = str(uuid.uuid4())
         self.test_mobileapp_deployment_mechanism = 1
         self.test_mobileapp_current_version = str(uuid.uuid4())
@@ -133,6 +134,7 @@ class MobileappsApiTests(ModuleStoreTestCase, APIClientMixin):
             'name': mobileapp_data.get('name', self.test_mobileapp_name),
             'android_app_id': mobileapp_data.get('android_app_id', self.test_mobileapp_android_app_id),
             'ios_app_id': mobileapp_data.get('ios_app_id', self.test_mobileapp_ios_app_id),
+            'ios_bundle_id': mobileapp_data.get('ios_bundle_id', self.test_mobileapp_ios_bundle_id),
             'current_version': mobileapp_data.get('current_version', self.test_mobileapp_current_version),
             'deployment_mechanism': mobileapp_data.get(
                 'deployment_mechanism', self.test_mobileapp_deployment_mechanism),
@@ -175,6 +177,8 @@ class MobileappsApiTests(ModuleStoreTestCase, APIClientMixin):
             self.assertEqual(len(mobileapp['organizations']), len(organizations))
             self.assertIsNotNone(mobileapp['created'])
             self.assertIsNotNone(mobileapp['modified'])
+            self.assertIsNotNone(mobileapp['ios_app_id'])
+            self.assertIsNotNone(mobileapp['ios_bundle_id'])
 
         # fetch data with page outside range
         response = self.do_get('{}?page=5'.format(self.base_mobileapps_uri))
@@ -323,7 +327,8 @@ class MobileappsApiTests(ModuleStoreTestCase, APIClientMixin):
 
     def test_mobileapps_detail_get(self):
         mobileapp_data = self.setup_test_mobileapp(mobileapp_data={
-            "name": 'ABC App', "provider_key": "ABC key", "provider_secret": "ABC secret"
+            "name": 'ABC App', "provider_key": "ABC key",
+            "provider_secret": "ABC secret", "ios_bundle_id": "com.example.testing.app"
         })
 
         response = self.do_get(reverse('mobileapps-detail', kwargs={'pk': mobileapp_data['id']}))
@@ -333,6 +338,7 @@ class MobileappsApiTests(ModuleStoreTestCase, APIClientMixin):
         self.assertEqual(response.data['is_active'], True)
         self.assertIn("android_app_id", response.data)
         self.assertIn("ios_app_id", response.data)
+        self.assertEqual(response.data["ios_bundle_id"], "com.example.testing.app")
         self.assertIn("deployment_mechanism", response.data)
         self.assertIn("ios_download_url", response.data)
         self.assertIn("android_download_url", response.data)
@@ -350,6 +356,7 @@ class MobileappsApiTests(ModuleStoreTestCase, APIClientMixin):
             name='ABC App',
             current_version=self.test_mobileapp_current_version,
             ios_app_id=self.test_mobileapp_ios_app_id,
+            ios_bundle_id=self.test_mobileapp_ios_bundle_id,
             android_app_id=self.test_mobileapp_android_app_id,
             deployment_mechanism=self.test_mobileapp_deployment_mechanism,
             updated_by=self.user,
@@ -367,6 +374,7 @@ class MobileappsApiTests(ModuleStoreTestCase, APIClientMixin):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data['name'], data['name'])
         self.assertEqual(response.data['ios_app_id'], mobileapp.ios_app_id)
+        self.assertEqual(response.data['ios_bundle_id'], mobileapp.ios_bundle_id)
         self.assertEqual(response.data['android_app_id'], mobileapp.android_app_id)
         self.assertEqual(response.data['updated_by'], self.user.id)
         self.assertEqual(response.data['is_active'], mobileapp.is_active)
@@ -376,6 +384,7 @@ class MobileappsApiTests(ModuleStoreTestCase, APIClientMixin):
             name='ABC App',
             current_version=self.test_mobileapp_current_version,
             ios_app_id=self.test_mobileapp_ios_app_id,
+            ios_bundle_id=self.test_mobileapp_ios_bundle_id,
             android_app_id=self.test_mobileapp_android_app_id,
             deployment_mechanism=self.test_mobileapp_deployment_mechanism,
             updated_by=self.user,
@@ -389,6 +398,7 @@ class MobileappsApiTests(ModuleStoreTestCase, APIClientMixin):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data['name'], data['name'])
         self.assertEqual(response.data['ios_app_id'], mobileapp.ios_app_id)
+        self.assertEqual(response.data['ios_bundle_id'], mobileapp.ios_bundle_id)
         self.assertEqual(response.data['android_app_id'], mobileapp.android_app_id)
         self.assertEqual(response.data['updated_by'], self.user.id)
         self.assertEqual(response.data['is_active'], mobileapp.is_active)

--- a/mobileapps/views.py
+++ b/mobileapps/views.py
@@ -104,6 +104,7 @@ class MobileAppView(MobileListCreateAPIView):
 
         * name: Name of the app,
         * ios_app_id: ios app ID
+        * ios_bundle_id: ios app's bundle ID
         * android_app_id: Android app ID
         * ios_download_url: IOS Download URL of the app.
         * android_download_url: Android Download URL of the app.
@@ -135,6 +136,7 @@ class MobileAppView(MobileListCreateAPIView):
         * modified: Datetime it was modified in.
         * name: Name of the app,
         * ios_app_id: ios app ID
+        * ios_bundle_id: ios app's bundle ID
         * android_app_id: Android app ID
         * ios_download_url: IOS Download URL of the app.
         * android_download_url: Android Download URL of the app.
@@ -163,6 +165,7 @@ class MobileAppView(MobileListCreateAPIView):
         * modified: Datetime it was modified in.
         * name: Name of the app,
         * ios_app_id: ios app ID
+        * ios_bundle_id: ios app's bundle ID
         * android_app_id: Android app ID
         * ios_download_url: IOS Download URL of the app.
         * android_download_url: Android Download URL of the app.
@@ -232,6 +235,7 @@ class MobileAppDetailView(MobileRetrieveUpdateAPIView):
 
         * name: Name of the app,
         * ios_app_id: ios app ID
+        * ios_bundle_id: ios app's bundle ID
         * android_app_id: Android app ID
         * ios_download_url: IOS Download URL of the app.
         * android_download_url: Android Download URL of the app.
@@ -263,6 +267,7 @@ class MobileAppDetailView(MobileRetrieveUpdateAPIView):
         * modified: Datetime it was modified in.
         * name: Name of the app,
         * ios_app_id: ios app ID
+        * ios_bundle_id: ios app's bundle ID
         * android_app_id: Android app ID
         * ios_download_url: IOS Download URL of the app.
         * android_download_url: Android Download URL of the app.


### PR DESCRIPTION
This PR has changes to add new field `ios_bundle_id` to mobileapps. [YONK-851](https://openedx.atlassian.net/browse/YONK-851) has details of the requirements.
@aamishbaloch could you please review?