### PR TITLE
YONK-876: Remove Image API added for mobile app themes

### DIFF
--- a/mobileapps/image_helpers.py
+++ b/mobileapps/image_helpers.py
@@ -141,6 +141,15 @@ def create_images(image_file, image_names, image_backend):
             storage.save(name, scaled_image_file)
 
 
+def remove_images(image_backend, image_names):
+    """
+    Physically remove the image files specified in `image_names`
+    """
+    storage = get_image_storage(image_backend)
+    for name in image_names.values():
+        storage.delete(name)
+
+
 def get_image_urls_by_key(
         secret_key,
         custom_key,

--- a/mobileapps/tests.py
+++ b/mobileapps/tests.py
@@ -1612,3 +1612,82 @@ class MobileappsThemeApiTests(ModuleStoreTestCase, APIClientMixin):
 
         for key, value in settings.ORGANIZATION_HEADER_BG_IMAGE_SIZES_MAP.items():
             self.assertNotIn('image_url_{}'.format(key), response.data['header_bg_image'])
+
+    def test_mobileapps_organization_theme_remove_image(self):
+        organization_theme = Theme.objects.create(
+            name='Blue',
+            logo_image_uploaded_at=TEST_LOGO_IMAGE_UPLOAD_DT,
+            header_bg_image_uploaded_at=TEST_HEADER_BG_IMAGE_UPLOAD_DT,
+            active=True,
+            organization=self.organization1,
+        )
+
+        response = self.do_delete(reverse(
+            'mobileapps-organization-themes-remove-image', kwargs={
+                'theme_id': organization_theme.id,
+                'attribute': 'logo_image'
+            }
+        ))
+        self.assertEqual(response.status_code, 200)
+
+        response = self.do_delete(reverse(
+            'mobileapps-organization-themes-remove-image', kwargs={
+                'theme_id': organization_theme.id,
+                'attribute': 'header_bg_image'
+            }
+        ))
+        self.assertEqual(response.status_code, 200)
+
+        response = self.do_get(reverse(
+            'mobileapps-organization-themes-detail', kwargs={
+                'theme_id': organization_theme.id,
+            }
+        ))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data['logo_image']['has_image'], False)
+        self.assertEqual(response.data['header_bg_image']['has_image'], False)
+
+    def test_mobileapps_organization_theme_remove_image_with_invalid_data(self):
+        invalid_theme_id = 101
+        invalid_attribute = 'logo_image_remove'
+        organization_theme = Theme.objects.create(
+            name='Blue',
+            logo_image_uploaded_at=TEST_LOGO_IMAGE_UPLOAD_DT,
+            header_bg_image_uploaded_at=TEST_HEADER_BG_IMAGE_UPLOAD_DT,
+            active=True,
+            organization=self.organization1,
+        )
+
+        response = self.do_delete(reverse(
+            'mobileapps-organization-themes-remove-image', kwargs={
+                'theme_id': invalid_theme_id,
+                'attribute': 'logo_image'
+            }
+        ))
+        self.assertEqual(response.status_code, 404)
+
+        response = self.do_delete(reverse(
+            'mobileapps-organization-themes-remove-image', kwargs={
+                'theme_id': organization_theme.id,
+                'attribute': invalid_attribute
+            }
+        ))
+        self.assertEqual(response.status_code, 400)
+
+        response = self.do_delete(reverse(
+            'mobileapps-organization-themes-remove-image', kwargs={
+                'theme_id': organization_theme.id,
+                'attribute': 'logo_image'
+            }
+        ))
+        self.assertEqual(response.status_code, 200)
+
+        response = self.do_get(reverse(
+            'mobileapps-organization-themes-detail', kwargs={
+                'theme_id': organization_theme.id,
+            }
+        ))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data['logo_image']['has_image'], False)

--- a/mobileapps/urls.py
+++ b/mobileapps/urls.py
@@ -24,4 +24,7 @@ urlpatterns = patterns(
     url(r'^themes/(?P<theme_id>[0-9]+)$',
         mobile_views.OrganizationThemeDetailView.as_view(),
         name='mobileapps-organization-themes-detail'),
+    url(r'^themes/(?P<theme_id>[0-9]+)/remove/(?P<attribute>[\w\_]+)$',
+        mobile_views.OrganizationThemeRemoveImageView.as_view(),
+        name='mobileapps-organization-themes-remove-image'),
 )

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='mobileapps-edx-platform-extensions',
-    version='1.1.8',
+    version='1.1.9',
     description='Mobile apps management extension for edX platform',
     long_description=open('README.md').read(),
     author='edX',


### PR DESCRIPTION
Changes include addition of API which can remove image (logo or header) of any theme of the specified mobile app. Unit tests also included.